### PR TITLE
Player doesn't gain full speed until it isfully standing

### DIFF
--- a/scripts/pmove.gd
+++ b/scripts/pmove.gd
@@ -35,6 +35,7 @@ var impact_velocity : float = 0.0
 var is_dead : bool = false
 var jump_press : bool = false
 var crouch_press : bool = false
+var toggle_walk : bool = false
 var ground_plane : bool = false
 var prev_y : float = 0.0
 var velocity : Vector3 = Vector3.ZERO
@@ -48,6 +49,11 @@ _input
 ===============
 """
 func _input(_event):
+	if Input.is_key_pressed(KEY_CAPSLOCK):
+		if toggle_walk:
+			toggle_walk = false
+		else:
+			toggle_walk = true
 	
 	if Input.is_key_pressed(KEY_K):
 		is_dead = true if !is_dead else false
@@ -71,9 +77,12 @@ func _input(_event):
 	
 	if Input.is_action_pressed("crouch"):
 		crouch_press = true
+		if movespeed == MAXSPEED:
+			movespeed = WALKSPEED
+		else:
+			movespeed = WALKSPEED / 2.0
 	else:
 		crouch_press = false
-	
 
 """
 ===============
@@ -107,9 +116,7 @@ crouch
 func crouch():
 	var crouch_speed = 20.0 * deltaTime
 	
-	if collider.shape.height >= (PLAYER_HEIGHT - 0.1):
-		movespeed = MAXSPEED
-	else:
+	if collider.shape.height <= (PLAYER_HEIGHT - 0.1):
 		movespeed = WALKSPEED
 	
 	if crouch_press:

--- a/scripts/pmove.gd
+++ b/scripts/pmove.gd
@@ -71,10 +71,6 @@ func _input(_event):
 	
 	if Input.is_action_pressed("crouch"):
 		crouch_press = true
-		if movespeed == MAXSPEED:
-			movespeed = WALKSPEED
-		else:
-			movespeed = WALKSPEED / 2.0
 	else:
 		crouch_press = false
 	
@@ -110,6 +106,11 @@ crouch
 """
 func crouch():
 	var crouch_speed = 20.0 * deltaTime
+	
+	if collider.shape.height >= (PLAYER_HEIGHT - 0.1):
+		movespeed = MAXSPEED
+	else:
+		movespeed = WALKSPEED
 	
 	if crouch_press:
 		# snap crouch height while falling


### PR DESCRIPTION
This ensures that the player is fully standing before giving the speed back.

The `- 0.1` is a duct tape solution. Originally, I had `if collider.shape.height >= PLAYER_HEIGHT` and even though both values were 3.6, it would output as false. I also tried storing the player height in another variable and using == but that didn't work as well.
I also added a walking toggle variable that can be toggled with CapsLock.